### PR TITLE
New method for rapid messageformat validation error handling

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -47,15 +47,15 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev.yaml,nais/alerts-dev.yaml
-#  deploy-prod:
-#    name: Deploy to Production
-#    needs: [build, deploy-dev]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: nais/deploy/actions/deploy@v1
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml
+  deploy-prod:
+    name: Deploy to Production
+    needs: [build, deploy-dev]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -34,7 +34,6 @@ jobs:
           docker build -t $IMAGE .
           docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker push $IMAGE
-
   deploy-dev:
     name: Deploy to dev
     needs: build

--- a/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/OppgaveDataSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/OppgaveDataSink.kt
@@ -26,8 +26,7 @@ internal class OppgaveDataSink(
     rapidsConnection: RapidsConnection,
     private val oppgaveClient: OppgaveClient,
     private val pdlClient: PdlClient
-) :
-    River.PacketListener {
+) : PacketListenerWithOnError {
 
     init {
         River(rapidsConnection).apply {

--- a/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/PacketListenerWithOnError.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/PacketListenerWithOnError.kt
@@ -1,0 +1,17 @@
+package no.nav.hjelpemidler.oppgave.service
+
+import mu.KotlinLogging
+import no.nav.helse.rapids_rivers.MessageProblems
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+
+class RiverRequiredKeyMissingException(msg: String) : Exception(msg)
+
+interface PacketListenerWithOnError : River.PacketListener {
+    override fun onError(problems: MessageProblems, context: RapidsConnection.MessageContext) {
+        sikkerlogg.info("River required keys had problems in parsing message from rapid: ${problems.toExtendedReport()}")
+        throw RiverRequiredKeyMissingException("River required keys had problems in parsing message from rapid, see Kibana index tjenestekall-* (sikkerlogg) for details")
+    }
+}

--- a/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/PapirsoeknadSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/oppgave/service/PapirsoeknadSink.kt
@@ -11,8 +11,7 @@ private val sikkerlogg = KotlinLogging.logger("tjenestekall")
 
 internal class PapirsoeknadSink(
     rapidsConnection: RapidsConnection,
-) :
-    River.PacketListener {
+) : PacketListenerWithOnError {
 
     init {
         River(rapidsConnection).apply {


### PR DESCRIPTION
Vi har demandValue for å kvalifisere at noe er ment for en gitt river, og requireKey for verdier vi er avhengige av at eksisterer for å kunne prosessere meldingen. Videre har vi en onError-funksjon implementert som logger problemene med en melding hvis den har passert demandValue men har feilet på et eller flere requireKey sjekker. Videre vil onError kaste en exception og stoppe opp prosessering slik at vi blir nødt å fikse problemet før meldingen kan passere (dermed mister vi ingenting mellom stoler). Før-situasjonen der demandValue var brukt var at vi stille ignorerte meldinger.

Eksempel: noen endrer meldingsformat på vei ut av hm-soknadsbehandling uten at hm-ditt-nav først er lansert med støtte for det nye formatet. Da vil hm-ditt-nav gå i en feil-loop slik at vi merker feilen og kan fikse den uten at vi mister meldinger. Da vil den plukke opp alt den skulle gjort etter problemet er fikset. Dette lar oss også gjøre slike ting med vilje. Ødelegge prosessering up-stream og se hvor ting feiler down-stream. Mindre viktig å fikse R&R ting i korrekt rekkefølge.